### PR TITLE
[FEAT] 관리페이지 진입 시, 토큰 확인 후 자동인증

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
   createBrowserRouter,
   RouterProvider,
   Navigate,
+  redirect,
 } from 'react-router-dom';
 import PasswordPage from '@/pages/co-buying/password/page';
 import DetailPage from '@/pages/co-buying/[id]/page';
@@ -13,9 +14,23 @@ import CoBuyingPage from '@/pages/co-buying/page';
 import { useKakaoInit } from '@/hooks/useKakaoInit';
 import ProtectedRoute from '@/routes/ProtectedRoute';
 import RefPage from '@/pages/ref';
+import useAuthStore from '@/stores/authStore';
+import { useEffect } from 'react';
+import { authService } from '@/api/services/auth';
 
 function App() {
   useKakaoInit(); // 카카오 초기화
+
+  useEffect(() => {
+    // 첫로그인시 리프레시 토큰 갱신
+    const refreshTokens = async () => {
+      const newToken = await authService.refreshToken();
+      if (newToken) {
+        useAuthStore.getState().setToken(newToken);
+      }
+    };
+    refreshTokens();
+  }, []);
 
   const router = createBrowserRouter([
     {
@@ -28,14 +43,33 @@ function App() {
       path: '/co-buying',
       children: [
         { index: true, element: <CoBuyingPage /> },
-        { path: ':id', element: <DetailPage /> }, // 공구글 상세페이지
-        { path: ':id/password', element: <PasswordPage /> }, // 관리하기 페이지 들어가기 전 비밀번호
+        {
+          path: ':id',
+          element: <DetailPage />, // 공구글 상세페이지
+        },
+        {
+          path: ':id/password',
+          element: <PasswordPage />,
+        }, // 관리하기 페이지 들어가기 전 비밀번호
         { path: 'create', element: <CreatePage /> }, // 공구글 작성페이지
       ],
     },
     {
       path: '/co-buying/:id/management',
       element: <ProtectedRoute />,
+      loader: async ({ params, request }) => {
+        const url = new URL(request.url);
+        const ownerName = url.searchParams.get('ownerName');
+        const accessToken = useAuthStore.getState().token;
+
+        if (accessToken) {
+          return null;
+        } else {
+          return redirect(
+            `/co-buying/${params.id}/password?ownerName=${encodeURIComponent(ownerName!)}`
+          );
+        }
+      },
       children: [
         { index: true, element: <ManagementPage /> }, // 공구글 관리페이지
       ],

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,12 +22,9 @@ function App() {
   useKakaoInit(); // 카카오 초기화
 
   useEffect(() => {
-    // 첫로그인시 리프레시 토큰 갱신
+    // 첫로그인 시 리프레시 토큰 갱신
     const refreshTokens = async () => {
-      const newToken = await authService.refreshToken();
-      if (newToken) {
-        useAuthStore.getState().setToken(newToken);
-      }
+      await authService.refreshToken();
     };
     refreshTokens();
   }, []);

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -36,7 +36,6 @@ privateAxiosInstance.interceptors.response.use(
       try {
         const newAccessToken = await authService.refreshToken();
         if (newAccessToken) {
-          useAuthStore.getState().setToken(newAccessToken); // 최신 토큰 저장
           error.config.headers.Authorization = `Bearer ${newAccessToken}`;
           return privateAxiosInstance.request(error.config);
         }

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -9,6 +9,6 @@ export const ENDPOINTS = {
   },
   AUTH: {
     PWD_CHECK: (id: string) => `/co-buying/auth/${id}`,
-    REFRESH_TOKEN: '/auth/refresh',
+    REFRESH_TOKEN: '/refresh',
   },
 } as const;

--- a/src/api/mutations/usePwdCobuying.ts
+++ b/src/api/mutations/usePwdCobuying.ts
@@ -3,26 +3,25 @@ import { cobuyingService } from '@/api/services/cobuying';
 import useAuthStore from '@/stores/authStore';
 import useAlertStore from '@/stores/alertStore';
 import { UserAuthReq } from '@interface/auth';
+import { AxiosError } from 'axios';
 
 export default function usePwdCobuying(id: string) {
-  const { setToken } = useAuthStore.getState();
+  const { setToken, setOwnerName } = useAuthStore.getState();
   const { showAlert } = useAlertStore();
 
   return useMutation({
-    mutationFn: async (body: UserAuthReq) => {
-      const result = await cobuyingService.pwdCheck(id, body);
-
-      if (result.success) {
-        setToken(result.token.split(' ')[1]); // ✅ 성공 시 토큰 저장
-        return true; // 인증 성공 여부
-      } else {
+    mutationFn: (body: UserAuthReq) => cobuyingService.pwdCheck(id, body),
+    onSuccess: (data) => {
+      setToken(data.headers['authorization'].split(' ')[1]); // ✅ 성공 시 토큰 저장
+      setOwnerName(data.data.ownerName);
+    },
+    onError: (error) => {
+      if (error instanceof AxiosError && error.response?.status === 401) {
         showAlert({
           status: 'fail',
           label: '비밀번호가 일치하지 않아요.',
         });
       }
-    },
-    onError: (error) => {
       console.error('🚨 비밀번호 요청 실패:', error);
     },
   });

--- a/src/api/services/auth.ts
+++ b/src/api/services/auth.ts
@@ -4,11 +4,9 @@ import axios from 'axios';
 export const authService = {
   refreshToken: async () => {
     try {
-      const response = await axios.post(
-        ENDPOINTS.AUTH.REFRESH_TOKEN,
-        {},
-        { withCredentials: true }
-      );
+      const response = await axios.get(ENDPOINTS.AUTH.REFRESH_TOKEN, {
+        withCredentials: true,
+      });
       return response.data;
     } catch (error) {
       console.error('리프레시 토큰 만료!!', error);

--- a/src/api/services/auth.ts
+++ b/src/api/services/auth.ts
@@ -1,13 +1,17 @@
+import { axiosInstance } from '@/api/axios';
 import { ENDPOINTS } from '@/api/endpoints';
-import axios from 'axios';
+import useAuthStore from '@/stores/authStore';
 
 export const authService = {
   refreshToken: async () => {
     try {
-      const response = await axios.get(ENDPOINTS.AUTH.REFRESH_TOKEN, {
+      const response = await axiosInstance.get(ENDPOINTS.AUTH.REFRESH_TOKEN, {
         withCredentials: true,
       });
-      return response.data;
+      const newToken = response.headers['authorization'].split(' ')[1];
+      useAuthStore.getState().setToken(newToken);
+      useAuthStore.getState().setOwnerName(response.data.ownerName);
+      return newToken;
     } catch (error) {
       console.error('리프레시 토큰 만료!!', error);
       return null;

--- a/src/api/services/cobuying.ts
+++ b/src/api/services/cobuying.ts
@@ -10,7 +10,6 @@ import {
   CoBuyingSummary,
 } from '@interface/cobuying';
 import { CoBuyingPageingRes } from '@interface/cobuyingList';
-import { AxiosError } from 'axios';
 
 export const cobuyingService = {
   postCreate: async (
@@ -45,19 +44,11 @@ export const cobuyingService = {
     return response.data;
   },
   pwdCheck: async (id: string, body: UserAuthReq) => {
-    try {
-      const response = await axiosInstance.post(
-        ENDPOINTS.AUTH.PWD_CHECK(id),
-        body
-      );
-
-      const token = response.headers['authorization'];
-      return { success: true, token };
-    } catch (error) {
-      if (error instanceof AxiosError && error.response?.status === 401) {
-        return { success: false };
-      }
-      throw error; // 기타 에러는 그대로 throw
-    }
+    const response = await axiosInstance.post(
+      ENDPOINTS.AUTH.PWD_CHECK(id),
+      body,
+      { withCredentials: true }
+    );
+    return response;
   },
 };

--- a/src/components/Header/RightButtonHeader.tsx
+++ b/src/components/Header/RightButtonHeader.tsx
@@ -20,7 +20,7 @@ export default function RightButtonHeader({
   };
 
   return (
-    <div className="flex items-center justify-between w-full px-4 py-4 text-black bg-white typo-h3-bold">
+    <div className="flex items-center justify-between w-full px-4 py-4 text-black bg-white h typo-h3-bold">
       <ArrowLeft
         stroke="#262626"
         width={18}

--- a/src/components/Header/TitleHeader.tsx
+++ b/src/components/Header/TitleHeader.tsx
@@ -17,7 +17,7 @@ function TitleHeader({ title, onBackPress }: TitleHeaderProps) {
   };
 
   return (
-    <div className=" py-4 flex items-center pl-4 text-black typo-h3-bold pr-[34px] w-full bg-white">
+    <div className="h-[53px] py-4 flex items-center pl-4 text-black typo-h3-bold pr-[34px] w-full bg-white">
       <ArrowLeft
         stroke="#262626"
         width={18}

--- a/src/pages/co-buying/[id]/info-section.tsx
+++ b/src/pages/co-buying/[id]/info-section.tsx
@@ -71,7 +71,7 @@ export default function InfoSection({ data }: { data: CoBuyingDetail }) {
           </section>
         </>
       )}
-      <section className="flex justify-end gap-2.5">
+      <section className="flex justify-end gap-2.5 ">
         <button
           className="px-2.5 py-2.5 rounded-full bg-primary-50 active:brightness-90"
           onClick={() => share(`${data.productName} 공구해요`)}

--- a/src/pages/co-buying/[id]/management/applyList-section.tsx
+++ b/src/pages/co-buying/[id]/management/applyList-section.tsx
@@ -16,7 +16,10 @@ export default function ApplyListSection({ data }: { data: CoBuyingDetail }) {
         </thead>
         <tbody>
           {attendeeList?.map((attendee) => (
-            <tr className="*:py-1.5 *:text-center *:typo-caption">
+            <tr
+              key={attendee.attendeeName}
+              className="*:py-1.5 *:text-center *:typo-caption"
+            >
               <td className="min-w-[30%]">{attendee.attendeeName}</td>
               <td>{attendee.appliedQuantity}</td>
               <td className="min-w-[45%]">

--- a/src/pages/co-buying/[id]/page.tsx
+++ b/src/pages/co-buying/[id]/page.tsx
@@ -23,8 +23,8 @@ export default function DetailPage() {
   const [isApplyingFormOpen, setIsApplyingFormOpen] = useState(false);
 
   const handleManageButton = () => {
-    // 관리하기 비밀번호 페이지
-    navigate(`password/?ownerName=${searchParams.get('ownerName')}`);
+    // 관리하기 페이지
+    navigate(`management?ownerName=${searchParams.get('ownerName')}`);
   };
 
   return (

--- a/src/pages/co-buying/password/page.tsx
+++ b/src/pages/co-buying/password/page.tsx
@@ -14,16 +14,19 @@ export default function PasswordPage() {
   const ownerName = searchParams.get('ownerName')!;
   const id = useParams().id!;
 
-  const { mutateAsync } = usePwdCobuying(id);
+  const { mutate } = usePwdCobuying(id);
 
   const [ownerPassword, setOwnerPassword] = useState('');
 
-  const handleSubmit = async () => {
-    const success = await mutateAsync({ ownerName, ownerPassword });
-
-    if (success) {
-      navigate(`/co-buying/${id}/management?ownerName=${ownerName}`);
-    }
+  const handleSubmit = () => {
+    mutate(
+      { ownerName, ownerPassword },
+      {
+        onSuccess: () => {
+          navigate(`/co-buying/${id}/management?ownerName=${ownerName}`);
+        },
+      }
+    );
   };
 
   return (


### PR DESCRIPTION
## Changed
- As is:  상세페이지 -> 비밀번호페이지 -> 비밀번호 입력 -> 인증확인 -> 관리페이지
- To be: 상세페이지 -> 관리페이지 -> 인증확인 -> 인증되지 않은 접근이면 비밀번호 페이지로 리다이렉트
- App.tsx에서 처음 웹 실행 시, refresh api 요청을 통해 accessToken을 재발급 
- refresh 할 때, 응답 값으로 ownerName을 받기로 함. 

## Why
- 액세스토큰을 발급받은 유저에 대해 관리하기 페이지를 비밀번호페이지를 걸치지 않고 보내기 위함
- refreshToken이 유효할 동안 비밀번호페이지를 가지않고도 관리페이지로 바로 들어가도록 하기 위함
- 

## How
- Router의 관리페이지에 loader에서 accessToken을 확인하고, 유효하지 않으면 비밀번호 페이지로 redirect시킴

## TroubleShooting
`Unexpected Application Error!
Failed to execute 'set' on 'Headers': String contains non ISO-8859-1 code point.`

=> React Router의 redirect 함수는 내부적으로 Headers.set()을 사용해 리다이렉트를 처리하는데 이때 한글이 포함돼 오류가 발생함
`encodeURIComponent()`를 사용해 인코딩해주어야 함. 