### PR TITLE
Fix: 수량 나눔 시 옵션별 부담액 계산 로직 개선

### DIFF
--- a/src/components/ApplyStateCard/index.tsx
+++ b/src/components/ApplyStateCard/index.tsx
@@ -10,21 +10,23 @@ import { useParams, useSearchParams } from "react-router-dom";
 interface ApplyStateCardProps {
   attendeeData: Attendee;
   showCheckbox?: boolean;
+  unitPrice?: number;
 }
 
 export default function ApplyStateCard({
   attendeeData,
   showCheckbox = false,
+  unitPrice,
 }: ApplyStateCardProps) {
   const { id } = useParams();
   const [searchParams] = useSearchParams();
   const ownerName = searchParams.get("ownerName")!;
 
   const { mutate } = useSharingCheck(id!, ownerName);
-  const totalQuantity = attendeeData.options?.reduce(
-    (acc, option) => acc + option.quantity,
-    0
-  );
+  // const totalQuantity = attendeeData.options?.reduce(
+  //   (acc, option) => acc + option.quantity,
+  //   0
+  // );
 
   // attendeeName이 ownerName과 같으면 "공구장" 으로 표기
   const isOwner = attendeeData.name === ownerName;
@@ -60,7 +62,7 @@ export default function ApplyStateCard({
           <OptionItem
             key={option.optionId}
             option={option}
-            perPrice={attendeeData.totalPrice / totalQuantity!}
+            perPrice={unitPrice ? unitPrice * option.quantity : 0}
           />
         ))}
         <div className="flex justify-between *:font-medium *:typo-caption *:text-default-800">

--- a/src/pages/co-buying/[id]/applyList-section.tsx
+++ b/src/pages/co-buying/[id]/applyList-section.tsx
@@ -1,5 +1,13 @@
-import ApplyStateCard from '@/components/ApplyStateCard';
-import { CoBuyingDetail } from '@interface/cobuying';
+import ApplyStateCard from "@/components/ApplyStateCard";
+import { CoBuyingDetail, QuantityCoBuyingDetail } from "@interface/cobuying";
+import { DivideType } from "@domain/cobuying";
+
+// 타입 가드 함수
+function isQuantityCoBuying(
+  data: CoBuyingDetail
+): data is QuantityCoBuyingDetail {
+  return data.type === DivideType.quantity;
+}
 
 export default function ApplyListSection({
   data,
@@ -15,7 +23,12 @@ export default function ApplyListSection({
     <section className={className}>
       <p className="typo-caption text-default-500 mb-1.5">나눔 현황</p>
       {attendeeList?.map((attendee) => (
-        <ApplyStateCard attendeeData={attendee} showCheckbox={canEdit} />
+        <ApplyStateCard
+          key={attendee.name}
+          attendeeData={attendee}
+          showCheckbox={canEdit}
+          unitPrice={isQuantityCoBuying(data) ? data.unitPrice : undefined}
+        />
       ))}
     </section>
   );


### PR DESCRIPTION
## 문제 상황
- 옵션 신청 수량이 0개일 때 부담액이 'NaN'으로 표시되는 문제 발생
- 원인: 총 부담액을 총 신청 수량(0)으로 나누어 계산하여 0으로 나누기 문제 발생

## 해결 방법
1. 옵션별 부담액 계산 로직 변경
   - 기존: 총 부담액 ÷ 총 신청 수량
   - 변경: 단위 가격 × 옵션별 수량

2. 예외 처리 추가
   - 신청 수량이 0개일 경우 부담액을 0원으로 표시

## 기대 효과
- 옵션별 정확한 부담액 계산 가능
- 0개 신청 시에도 안정적으로 금액 표시